### PR TITLE
define show_last_message

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,12 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージがありません'
+    end
+  end
 end

--- a/app/views/devise/shared/_left_content.html.haml
+++ b/app/views/devise/shared/_left_content.html.haml
@@ -16,4 +16,4 @@
         .group--name
           = group.name
         .group--talk
-          メッセージはまだありません
+          = group.show_last_message


### PR DESCRIPTION
# show_last_messageの定義
* Groupモデルの中でshow_last_messageを定義した。
* 三項演算子をりようして、メッセージがあるときの画像があるパターンとないパターンを表示するようにした。